### PR TITLE
Add require-reactive-value-suffix rule

### DIFF
--- a/src/constants/constant.ts
+++ b/src/constants/constant.ts
@@ -1,0 +1,10 @@
+export const REACTIVE_FUNCTIONS = [
+  'ref',
+  'computed',
+  'reactive',
+  'toRef',
+  'toRefs',
+  'shallowRef',
+  'storeToRefs',
+] as const;
+export const COMPOSABLES_FUNCTION_PATTERN: RegExp = /^use[A-Z]/;

--- a/src/helpers/ast-helper.ts
+++ b/src/helpers/ast-helper.ts
@@ -1,5 +1,21 @@
 import { AST_NODE_TYPES, type TSESTree } from '@typescript-eslint/utils';
 
+/**
+ * 指定されたノードタイプに対する型ガード関数を生成するファクトリ関数です。
+ *
+ * @template T - チェックするノードの型
+ * @param nodeType - 判定するノードタイプ
+ * @returns 指定されたノードタイプに対する型ガード関数
+ *
+ * @example
+ * // Identifierノード用の型ガード関数を作成
+ * const isIdentifier = nodeTypeGuardFactory<TSESTree.Identifier>(AST_NODE_TYPES.Identifier);
+ *
+ * // 使用例
+ * if (isIdentifier(node)) {
+ *   // この中では、nodeはTSESTree.Identifierとして扱われる
+ * }
+ */
 const nodeTypeGuardFactory = <T extends TSESTree.Node>(nodeType: T['type']) => {
   return (node: TSESTree.Node): node is T => node.type === nodeType;
 };
@@ -110,3 +126,209 @@ export const isCallExpression = nodeTypeGuardFactory<TSESTree.CallExpression>(AS
  * }
  */
 export const isObjectPattern = nodeTypeGuardFactory<TSESTree.ObjectPattern>(AST_NODE_TYPES.ObjectPattern);
+
+/**
+ * 与えられたノードが非Null表明演算子（TSNonNullExpression）であるかどうかを判定します。
+ * この演算子はTypeScriptで!を使用してnullやundefinedではないことを表明する場合に使用されます。
+ *
+ * @param node - 検査するASTノード
+ * @returns ノードが非Null表明演算子の場合はtrue、それ以外の場合はfalse
+ *
+ * @example
+ * // 以下のASTノードを考えます:
+ * // const element = document.getElementById('id')!;
+ * // この場合、'document.getElementById('id')!'の!部分はTSNonNullExpressionノードになります
+ *
+ * // AST例:
+ * // {
+ * //   type: 'TSNonNullExpression',
+ * //   expression: { * 内部の式 * }
+ * // }
+ *
+ * if (isTSNonNullExpression(node)) {
+ *   console.log(node.expression); // 非Null表明が適用されている式にアクセス可能
+ * }
+ */
+export const isTSNonNullExpression = nodeTypeGuardFactory<TSESTree.TSNonNullExpression>(
+  AST_NODE_TYPES.TSNonNullExpression,
+);
+
+/**
+ * 与えられたノードが変数宣言（VariableDeclaration）であるかどうかを判定します。
+ *
+ * @param node - 検査するASTノード
+ * @returns ノードが変数宣言の場合はtrue、それ以外の場合はfalse
+ *
+ * @example
+ * // 以下のASTノードを考えます:
+ * // const x = 1, y = 2;
+ * // または
+ * // let value;
+ *
+ * // AST例:
+ * // {
+ * //   type: 'VariableDeclaration',
+ * //   kind: 'const', // または 'let', 'var'
+ * //   declarations: [* VariableDeclarator ノードの配列 *]
+ * // }
+ *
+ * if (isVariableDeclaration(node)) {
+ *   console.log(node.kind); // 'const', 'let', 'var' などの宣言の種類
+ *   console.log(node.declarations); // 宣言子の配列
+ * }
+ */
+export const isVariableDeclaration = nodeTypeGuardFactory<TSESTree.VariableDeclaration>(
+  AST_NODE_TYPES.VariableDeclaration,
+);
+
+/**
+ * 与えられたノードが変数宣言子（VariableDeclarator）であるかどうかを判定します。
+ * 変数宣言子は変数宣言の各部分を表します。
+ *
+ * @param node - 検査するASTノード
+ * @returns ノードが変数宣言子の場合はtrue、それ以外の場合はfalse
+ *
+ * @example
+ * // 以下のASTノードを考えます:
+ * // const x = 1;
+ * // この場合、'x = 1'の部分はVariableDeclaratorノードになります
+ *
+ * // AST例:
+ * // {
+ * //   type: 'VariableDeclarator',
+ * //   id: { type: 'Identifier', name: 'x' },
+ * //   init: { type: 'Literal', value: 1 }
+ * // }
+ *
+ * if (isVariableDeclarator(node)) {
+ *   console.log(node.id); // 変数の識別子
+ *   console.log(node.init); // 初期化式（存在する場合）
+ * }
+ */
+export const isVariableDeclarator = nodeTypeGuardFactory<TSESTree.VariableDeclarator>(
+  AST_NODE_TYPES.VariableDeclarator,
+);
+
+/**
+ * 与えられたノードが配列パターン（ArrayPattern）であるかどうかを判定します。
+ * 配列パターンは主に配列の分割代入で使用されます。
+ *
+ * @param node - 検査するASTノード
+ * @returns ノードが配列パターンの場合はtrue、それ以外の場合はfalse
+ *
+ * @example
+ * // 以下のASTノードを考えます:
+ * // const [a, b] = array;
+ * // この場合、'[a, b]'の部分はArrayPatternノードになります
+ *
+ * // AST例:
+ * // {
+ * //   type: 'ArrayPattern',
+ * //   elements: [
+ * //     { type: 'Identifier', name: 'a' },
+ * //     { type: 'Identifier', name: 'b' }
+ * //   ]
+ * // }
+ *
+ * if (isArrayPattern(node)) {
+ *   // 配列パターンの要素配列にアクセス可能
+ *   node.elements.forEach((element, index) => {
+ *     if (element && isIdentifier(element)) {
+ *       console.log(`Element at index ${index}: ${element.name}`);
+ *     }
+ *   });
+ * }
+ */
+export const isArrayPattern = nodeTypeGuardFactory<TSESTree.ArrayPattern>(AST_NODE_TYPES.ArrayPattern);
+
+/**
+ * 与えられたノードがオブジェクト式（ObjectExpression）であるかどうかを判定します。
+ *
+ * @param node - 検査するASTノード
+ * @returns ノードがオブジェクト式の場合はtrue、それ以外の場合はfalse
+ *
+ * @example
+ * // 以下のASTノードを考えます:
+ * // const obj = { a: 1, b: 2 };
+ * // この場合、'{ a: 1, b: 2 }'の部分はObjectExpressionノードになります
+ *
+ * // AST例:
+ * // {
+ * //   type: 'ObjectExpression',
+ * //   properties: [
+ * //     { type: 'Property', key: { type: 'Identifier', name: 'a' }, ... },
+ * //     { type: 'Property', key: { type: 'Identifier', name: 'b' }, ... }
+ * //   ]
+ * // }
+ *
+ * if (isObjectExpression(node)) {
+ *   // オブジェクト式のプロパティ配列にアクセス可能
+ *   node.properties.forEach(prop => {
+ *     if (isProperty(prop) && isIdentifier(prop.key)) {
+ *       console.log(`Property: ${prop.key.name}`);
+ *     }
+ *   });
+ * }
+ */
+export const isObjectExpression = nodeTypeGuardFactory<TSESTree.ObjectExpression>(AST_NODE_TYPES.ObjectExpression);
+
+/**
+ * 与えられたノードがメンバー式（MemberExpression）であるかどうかを判定します。
+ * メンバー式はオブジェクトのプロパティやメソッドへのアクセスを表します。
+ *
+ * @param node - 検査するASTノード
+ * @returns ノードがメンバー式の場合はtrue、それ以外の場合はfalse
+ *
+ * @example
+ * // 以下のASTノードを考えます:
+ * // obj.property
+ * // または
+ * // array[index]
+ *
+ * // AST例:
+ * // {
+ * //   type: 'MemberExpression',
+ * //   object: { type: 'Identifier', name: 'obj' },
+ * //   property: { type: 'Identifier', name: 'property' },
+ * //   computed: false
+ * // }
+ *
+ * if (isMemberExpression(node)) {
+ *   console.log(node.object); // アクセスされるオブジェクト
+ *   console.log(node.property); // アクセスされるプロパティ
+ *   console.log(node.computed); // 計算済みのアクセスか（[]を使用）どうか
+ * }
+ */
+export const isMemberExpression = nodeTypeGuardFactory<TSESTree.MemberExpression>(AST_NODE_TYPES.MemberExpression);
+
+/**
+ * 与えられたノードが配列式（ArrayExpression）であるかどうかを判定します。
+ *
+ * @param node - 検査するASTノード
+ * @returns ノードが配列式の場合はtrue、それ以外の場合はfalse
+ *
+ * @example
+ * // 以下のASTノードを考えます:
+ * // const arr = [1, 2, 3];
+ * // この場合、'[1, 2, 3]'の部分はArrayExpressionノードになります
+ *
+ * // AST例:
+ * // {
+ * //   type: 'ArrayExpression',
+ * //   elements: [
+ * //     { type: 'Literal', value: 1 },
+ * //     { type: 'Literal', value: 2 },
+ * //     { type: 'Literal', value: 3 }
+ * //   ]
+ * // }
+ *
+ * if (isArrayExpression(node)) {
+ *   // 配列式の要素配列にアクセス可能
+ *   node.elements.forEach((element, index) => {
+ *     if (element) {
+ *       console.log(`Element at index ${index}:`, element);
+ *     }
+ *   });
+ * }
+ */
+export const isArrayExpression = nodeTypeGuardFactory<TSESTree.ArrayExpression>(AST_NODE_TYPES.ArrayExpression);

--- a/src/helpers/function-checks.ts
+++ b/src/helpers/function-checks.ts
@@ -1,6 +1,14 @@
 import type { TSESTree } from '@typescript-eslint/utils';
-import type { PropertyWithIdentifier } from '../types/estree';
-import { isCallExpression, isIdentifier, isObjectPattern, isProperty } from './ast-helper';
+import { COMPOSABLES_FUNCTION_PATTERN } from '../constants/constant';
+import type { CallExpressionWithIdentifierCallee, PropertyWithIdentifier } from '../types/estree';
+import {
+  isArrayExpression,
+  isCallExpression,
+  isIdentifier,
+  isObjectExpression,
+  isObjectPattern,
+  isProperty,
+} from './ast-helper';
 
 /**
  * 変数宣言が `storeToRefs` 関数の呼び出し結果を分割代入しているかどうかを判定します。
@@ -75,4 +83,79 @@ export const isIdentifierPropertyPair = (
   property: TSESTree.Property | TSESTree.RestElement,
 ): property is PropertyWithIdentifier => {
   return isProperty(property) && isIdentifier(property.key) && isIdentifier(property.value);
+};
+
+export const isPropertyValue = (node: TSESTree.Node): boolean => isProperty(node) && isObjectExpression(node.parent);
+
+export const hasIdentifierCallee = (node: TSESTree.CallExpression): node is CallExpressionWithIdentifierCallee => {
+  return isIdentifier(node.callee);
+};
+
+export const findAncestorCallExpression = (node: TSESTree.Node): TSESTree.CallExpression | null => {
+  let currentNode: TSESTree.Node | undefined = node.parent;
+
+  while (currentNode) {
+    if (isCallExpression(currentNode)) {
+      return currentNode;
+    }
+    currentNode = currentNode.parent;
+  }
+
+  return null;
+};
+
+export const isWatchArgument = (node: TSESTree.Identifier): boolean => {
+  const callExpression = findAncestorCallExpression(node);
+  if (!callExpression) return false;
+
+  if (!hasIdentifierCallee(callExpression) || callExpression.callee.name !== 'watch') {
+    return false;
+  }
+
+  if (callExpression.arguments[0] === node) {
+    return true;
+  }
+
+  return isArrayExpression(callExpression.arguments[0]) && callExpression.arguments[0].elements.includes(node);
+};
+
+export const checkFunctionArgument = (
+  node: TSESTree.Identifier,
+  targetNode: TSESTree.CallExpression | null,
+  functionNames: ReadonlyArray<string>,
+): boolean => {
+  if (!targetNode) return false;
+
+  return (
+    targetNode.arguments.includes(node) &&
+    hasIdentifierCallee(targetNode) &&
+    functionNames.includes(targetNode.callee.name)
+  );
+};
+
+export const isSpecialFunctionArgument = (
+  node: TSESTree.Identifier,
+  specialFunctionNames: ReadonlyArray<string>,
+): boolean => {
+  const targetNode = findAncestorCallExpression(node);
+  return checkFunctionArgument(node, targetNode, specialFunctionNames);
+};
+
+export const isArgumentOfIgnoredFunction = (
+  node: TSESTree.Identifier,
+  ignoredFunctionNames: ReadonlyArray<string>,
+): boolean => {
+  const parent = isCallExpression(node.parent) ? node.parent : null;
+  return checkFunctionArgument(node, parent, ignoredFunctionNames);
+};
+
+export const isComposablesFunctionArgument = (node: TSESTree.Identifier): boolean => {
+  const callExpression = findAncestorCallExpression(node);
+  if (!callExpression) return false;
+
+  if (!hasIdentifierCallee(callExpression) || !COMPOSABLES_FUNCTION_PATTERN.test(callExpression.callee.name)) {
+    return false;
+  }
+
+  return callExpression.arguments.includes(node);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import type { ESLint, Linter } from 'eslint';
 import { version } from '../package.json';
+import { requireReactiveValueSuffix } from './rules/require-reactive-value-suffix';
 import { storeStateSuffix } from './rules/store-state-suffix';
 
 type RuleDefinitions = (typeof plugin)['rules'];
@@ -16,6 +17,7 @@ const plugin = {
   version,
   rules: {
     'store-state-suffix': storeStateSuffix,
+    'require-reactive-value-suffix': requireReactiveValueSuffix,
   },
 } satisfies ESLint.Plugin;
 

--- a/src/rules/require-reactive-value-suffix.ts
+++ b/src/rules/require-reactive-value-suffix.ts
@@ -1,0 +1,256 @@
+import type { ParserServices, TSESLint, TSESTree } from '@typescript-eslint/utils';
+import type { TypeChecker } from 'typescript';
+import { COMPOSABLES_FUNCTION_PATTERN, REACTIVE_FUNCTIONS } from '../constants/constant';
+import {
+  isArrayExpression,
+  isArrayPattern,
+  isCallExpression,
+  isIdentifier,
+  isMemberExpression,
+  isObjectPattern,
+  isProperty,
+  isTSNonNullExpression,
+  isVariableDeclaration,
+  isVariableDeclarator,
+} from '../helpers/ast-helper';
+import {
+  hasIdentifierCallee,
+  isArgumentOfIgnoredFunction,
+  isComposablesFunctionArgument,
+  isIdentifierPropertyPair,
+  isPropertyValue,
+  isSpecialFunctionArgument,
+  isWatchArgument,
+} from '../helpers/function-checks';
+import { createReportData, getTypeCheckingServices, getTypeString } from '../helpers/types';
+import type { CallExpressionWithIdentifierCallee, ObjectPatternCallExpressionDeclarator } from '../types/estree';
+import { createEslintRule, memoize } from '../utils';
+
+const MESSAGE_ID = 'require-reactive-value-suffix' as const;
+
+type MessageIds = typeof MESSAGE_ID;
+type RuleOptions = { functionNamesToIgnoreValueCheck?: string[] };
+type RuleContext = Readonly<TSESLint.RuleContext<MessageIds, RuleOptions[]>>;
+
+const needsValueSuffix = (
+  variableNode: TSESTree.Identifier,
+  typeChecker: TypeChecker,
+  parserServices: ParserServices,
+): boolean => {
+  const variableTypeString = getTypeString(variableNode, typeChecker, parserServices);
+
+  const isRefTypeVariable = variableTypeString.includes('Ref');
+  const isValueSuffixMissing = !variableTypeString.includes('.value');
+  const hasNonNullAssertion = isTSNonNullExpression(variableNode.parent);
+
+  return isRefTypeVariable && isValueSuffixMissing && !hasNonNullAssertion;
+};
+
+const getAllVariableDeclarators = (ruleContext: RuleContext): TSESTree.VariableDeclarator[] => {
+  return ruleContext.sourceCode.ast.body.flatMap((sourceNode) => {
+    if (isVariableDeclaration(sourceNode)) {
+      return sourceNode.declarations;
+    }
+    return [];
+  });
+};
+
+const getStoreToRefsVariableNames = (ruleContext: RuleContext): string[] => {
+  const isStoreToRefsDeclaration = (declaration: TSESTree.VariableDeclarator): boolean =>
+    isObjectPattern(declaration.id) &&
+    !!declaration.init &&
+    isCallExpression(declaration.init) &&
+    hasIdentifierCallee(declaration.init) &&
+    declaration.init.callee.name === 'storeToRefs';
+
+  const extractIdentifierNames = (declaration: TSESTree.VariableDeclarator): string[] => {
+    if (!isObjectPattern(declaration.id)) return [];
+
+    return declaration.id.properties.filter(isIdentifierPropertyPair).map((property) => property.value.name);
+  };
+
+  return getAllVariableDeclarators(ruleContext).filter(isStoreToRefsDeclaration).flatMap(extractIdentifierNames);
+};
+
+const getAllReactiveVariableNames = (ruleContext: RuleContext): string[] => {
+  const isReactiveFunctionCall = (declaration: TSESTree.VariableDeclarator): boolean =>
+    !!declaration.init &&
+    isCallExpression(declaration.init) &&
+    hasIdentifierCallee(declaration.init) &&
+    REACTIVE_FUNCTIONS.includes(declaration.init.callee.name as (typeof REACTIVE_FUNCTIONS)[number]);
+
+  const extractVariableNames = (declaration: TSESTree.VariableDeclarator): string[] => {
+    if (isIdentifier(declaration.id)) {
+      return [declaration.id.name];
+    }
+
+    if (isObjectPattern(declaration.id)) {
+      const identifierProperties = declaration.id.properties.filter(
+        (property): property is TSESTree.Property & { value: TSESTree.Identifier } =>
+          isProperty(property) && isIdentifier(property.value),
+      );
+
+      return identifierProperties.map((property) => property.value.name);
+    }
+
+    return [];
+  };
+
+  const reactiveVariableNames = getAllVariableDeclarators(ruleContext)
+    .filter((declaration): declaration is TSESTree.VariableDeclarator & { init: CallExpressionWithIdentifierCallee } =>
+      isReactiveFunctionCall(declaration),
+    )
+    .flatMap(extractVariableNames);
+
+  const storeToRefsVariableNames = getStoreToRefsVariableNames(ruleContext);
+
+  return [...reactiveVariableNames, ...storeToRefsVariableNames];
+};
+
+const getComposableFunctionVariableNames = (ruleContext: RuleContext): string[] => {
+  const isComposableFunctionCall = (declaration: TSESTree.VariableDeclarator): boolean =>
+    !!declaration.init &&
+    isCallExpression(declaration.init) &&
+    hasIdentifierCallee(declaration.init) &&
+    COMPOSABLES_FUNCTION_PATTERN.test(declaration.init.callee.name);
+
+  const extractPropertyVariableNames = (declaration: TSESTree.VariableDeclarator): string[] => {
+    if (!isObjectPattern(declaration.id)) return [];
+
+    return declaration.id.properties.filter(isIdentifierPropertyPair).map((property) => property.value.name);
+  };
+
+  return getAllVariableDeclarators(ruleContext)
+    .filter((declaration): declaration is ObjectPatternCallExpressionDeclarator =>
+      isComposableFunctionCall(declaration),
+    )
+    .flatMap(extractPropertyVariableNames);
+};
+
+const shouldSuppressWarning = (
+  node: TSESTree.Identifier,
+  parent: TSESTree.Node,
+  composableFunctions: ReadonlyArray<string>,
+  ignoredFunctionNames: ReadonlyArray<string>,
+): boolean => {
+  const isAliasedDestructuring = isProperty(parent) && parent.value === node && isObjectPattern(parent.parent);
+
+  const isInDeclarationContext =
+    isVariableDeclarator(parent) ||
+    isArrayPattern(parent) ||
+    (parent.parent && isPropertyValue(parent)) ||
+    isAliasedDestructuring;
+
+  const isPropertyAccess =
+    (isMemberExpression(parent) && isIdentifier(parent.property) && parent.property.name === 'value') ||
+    (isMemberExpression(parent) && parent.property !== node) ||
+    (isProperty(parent) && parent.key === node) ||
+    isPropertyValue(parent);
+
+  const isSpecialArgument =
+    isWatchArgument(node) ||
+    isSpecialFunctionArgument(node, composableFunctions) ||
+    isArgumentOfIgnoredFunction(node, ignoredFunctionNames) ||
+    isComposablesFunctionArgument(node);
+
+  const isInLiteral = isArrayExpression(node.parent);
+
+  return isInDeclarationContext || isPropertyAccess || isSpecialArgument || isInLiteral;
+};
+
+const processIdentifierNode = (
+  identifierNode: TSESTree.Identifier,
+  ruleContext: RuleContext,
+  reactiveVariableNames: ReadonlyArray<string>,
+  composableFunctionVariableNames: ReadonlyArray<string>,
+  ignoredFunctionNames: ReadonlyArray<string>,
+): void => {
+  if (!identifierNode.parent || !reactiveVariableNames.includes(identifierNode.name)) return;
+
+  if (
+    shouldSuppressWarning(identifierNode, identifierNode.parent, composableFunctionVariableNames, ignoredFunctionNames)
+  ) {
+    return;
+  }
+
+  const { parserServices, typeChecker } = getTypeCheckingServices(ruleContext);
+
+  if (needsValueSuffix(identifierNode, typeChecker, parserServices)) {
+    ruleContext.report(createReportData(identifierNode, MESSAGE_ID));
+  }
+};
+
+const processMemberExpressionNode = (
+  memberExpressionNode: TSESTree.MemberExpression,
+  ruleContext: RuleContext,
+  reactiveVariableNames: ReadonlyArray<string>,
+): void => {
+  if (!isIdentifier(memberExpressionNode.object) || !reactiveVariableNames.includes(memberExpressionNode.object.name)) {
+    return;
+  }
+
+  if (isIdentifier(memberExpressionNode.property) && memberExpressionNode.property.name === 'value') {
+    return;
+  }
+
+  if (isPropertyValue(memberExpressionNode.parent)) {
+    return;
+  }
+
+  const { parserServices, typeChecker } = getTypeCheckingServices(ruleContext);
+
+  if (needsValueSuffix(memberExpressionNode.object, typeChecker, parserServices)) {
+    ruleContext.report(createReportData(memberExpressionNode.object, MESSAGE_ID));
+  }
+};
+
+export const requireReactiveValueSuffix = createEslintRule({
+  name: 'require-reactive-value-suffix',
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Enforce using .value suffix when accessing reactive values in Vue.js',
+    },
+    messages: {
+      [MESSAGE_ID]: 'Reactive variable "{{name}}" should be accessed as "{{name}}.value"',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          functionNamesToIgnoreValueCheck: {
+            type: 'array',
+            items: { type: 'string' },
+            default: [],
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  defaultOptions: [{}],
+  create(ruleContext: RuleContext) {
+    const ruleOptions = ruleContext.options[0] || {};
+    const functionNamesToIgnoreValueCheck = ruleOptions.functionNamesToIgnoreValueCheck || [];
+
+    const getReactiveVariables = memoize(() => getAllReactiveVariableNames(ruleContext));
+    const getComposableFunctions = memoize(() => getComposableFunctionVariableNames(ruleContext));
+    const reactiveVariableList = getReactiveVariables();
+    const composableFunctionList = getComposableFunctions();
+
+    return {
+      Identifier(identifierNode) {
+        processIdentifierNode(
+          identifierNode,
+          ruleContext,
+          reactiveVariableList,
+          composableFunctionList,
+          functionNamesToIgnoreValueCheck,
+        );
+      },
+      MemberExpression(memberExpressionNode) {
+        processMemberExpressionNode(memberExpressionNode, ruleContext, reactiveVariableList);
+      },
+    };
+  },
+});

--- a/src/types/estree.d.ts
+++ b/src/types/estree.d.ts
@@ -19,3 +19,10 @@ import type { TSESTree } from '@typescript-eslint/utils';
  * }
  */
 export type PropertyWithIdentifier = TSESTree.Property & { key: TSESTree.Identifier; value: TSESTree.Identifier };
+
+export type CallExpressionWithIdentifierCallee = TSESTree.CallExpression & { callee: TSESTree.Identifier };
+
+export type ObjectPatternCallExpressionDeclarator = TSESTree.VariableDeclarator & {
+  id: TSESTree.ObjectPattern;
+  init: CallExpressionWithIdentifierCallee;
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,6 +11,16 @@ const blobTestUrl = 'https://github.com/XeicuLy/eslint-plugin-xeiculy/blob/main/
 
 export type RuleModule<TOptions extends readonly unknown[]> = Rule.RuleModule & { defaultOptions: TOptions };
 
+export const memoize = <T>(fn: () => T): (() => T) => {
+  let cached: T | undefined;
+  return () => {
+    if (cached === undefined) {
+      cached = fn();
+    }
+    return cached;
+  };
+};
+
 /**
  * 基本的なルールを作成する関数
  * @template TOptions ルールのオプション型


### PR DESCRIPTION
## 📝 プルリクエストの種類 / Pull Request Type

- [x] 機能追加 / Feature
- [ ] バグ修正 / Bug Fix
- [ ] パフォーマンス改善 / Performance Improvement
- [ ] リファクタリング / Refactoring
- [ ] ドキュメント / Documentation
- [ ] テスト / Test
- [ ] CI / CD
- [ ] その他 / Other

## 🔍 変更内容 / Changes Made

### 📋 概要 / Summary

新ルール追加

### ✅ 実施した変更 / Changes Implemented

- f454854ea49ba6b2b5a6413c2afbf231f0f2ce1a

### ❌ 対象外の変更 / Out of Scope

- テスト

## 🔗 関連Issue / Related Issues

n/a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Vueのリアクティブ変数（refやcomputedなど）へのアクセス時に `.value` サフィックスの使用を強制するESLintルールを追加しました。
  - このルールは、リアクティブ変数や特定のコンポーザブル関数の戻り値を識別し、必要な場合に `.value` の付与を促します。
- **その他**
  - 新しいユーティリティ関数や型定義の追加により、内部的なAST解析やパフォーマンスが向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->