### PR TITLE
Add restrict directive to template rule Add restrict-directive-to-template ESLint rule and related utilities

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,7 @@
 dist
 *.tgz
 temp
+CHANGELOG.md
 
 # Node dependencies
 node_modules

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@commitlint/cli": "19.8.0",
     "@types/eslint": "9.6.1",
     "@types/node": "22.15.3",
+    "@typescript-eslint/parser": "8.32.1",
     "@typescript-eslint/typescript-estree": "8.31.1",
     "@typescript-eslint/utils": "8.31.1",
     "@vitest/coverage-v8": "3.1.2",
@@ -64,7 +65,9 @@
     "vue-eslint-parser": "10.1.3"
   },
   "peerDependencies": {
-    "eslint": ">=9.0.0"
+    "@typescript-eslint/parser": ">=8.0.0",
+    "eslint": ">=9.0.0",
+    "vue-eslint-parser": ">=10.0.0"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -12,10 +12,7 @@
     "url": "git+https://github.com/XeicuLy/eslint-plugin-xeiculy.git"
   },
   "bugs": "https://github.com/XeicuLy/eslint-plugin-xeiculy/issues",
-  "keywords": [
-    "eslint",
-    "eslint-plugin"
-  ],
+  "keywords": ["eslint", "eslint-plugin"],
   "sideEffects": false,
   "exports": {
     ".": "./dist/index.mjs"
@@ -23,9 +20,7 @@
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "unbuild",
     "dev": "unbuild --stub",
@@ -65,7 +60,8 @@
     "typescript": "5.8.3",
     "unbuild": "3.5.0",
     "vite": "6.3.3",
-    "vitest": "3.1.2"
+    "vitest": "3.1.2",
+    "vue-eslint-parser": "10.1.3"
   },
   "peerDependencies": {
     "eslint": ">=9.0.0"
@@ -79,12 +75,8 @@
     }
   },
   "lint-staged": {
-    "**/*.{css,js,ts,cjs,mjs,cts,mts,jsx,tsx,json,jsonc}": [
-      "biome check --write --no-errors-on-unmatched"
-    ],
-    "**/*.{md,html,yaml,yml}": [
-      "prettier --write"
-    ]
+    "**/*.{css,js,ts,cjs,mjs,cts,mts,jsx,tsx,json,jsonc}": ["biome check --write --no-errors-on-unmatched"],
+    "**/*.{md,html,yaml,yml}": ["prettier --write"]
   },
   "volta": {
     "node": "22.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@types/node':
         specifier: 22.15.3
         version: 22.15.3
+      '@typescript-eslint/parser':
+        specifier: 8.32.1
+        version: 8.32.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3)
       '@typescript-eslint/typescript-estree':
         specifier: 8.31.1
         version: 8.31.1(typescript@5.8.3)
@@ -671,16 +674,37 @@ packages:
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
+  '@typescript-eslint/parser@8.32.1':
+    resolution: {integrity: sha512-LKMrmwCPoLhM45Z00O1ulb6jwyVr2kr3XJp+G+tSEZcbauNnScewcQwtJqXDhXeYPDEjZ8C1SjXm015CirEmGg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
   '@typescript-eslint/scope-manager@8.31.1':
     resolution: {integrity: sha512-BMNLOElPxrtNQMIsFHE+3P0Yf1z0dJqV9zLdDxN/xLlWMlXK/ApEsVEKzpizg9oal8bAT5Sc7+ocal7AC1HCVw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/scope-manager@8.32.1':
+    resolution: {integrity: sha512-7IsIaIDeZn7kffk7qXC3o6Z4UblZJKV3UBpkvRNpr5NSyLji7tvTcvmnMNYuYLyh26mN8W723xpo3i4MlD33vA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/types@8.31.1':
     resolution: {integrity: sha512-SfepaEFUDQYRoA70DD9GtytljBePSj17qPxFHA/h3eg6lPTqGJ5mWOtbXCk1YrVU1cTJRd14nhaXWFu0l2troQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.32.1':
+    resolution: {integrity: sha512-YmybwXUJcgGqgAp6bEsgpPXEg6dcCyPyCSr0CAAueacR/CCBi25G3V8gGQ2kRzQRBNol7VQknxMs9HvVa9Rvfg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.31.1':
     resolution: {integrity: sha512-kaA0ueLe2v7KunYOyWYtlf/QhhZb7+qh4Yw6Ni5kgukMIG+iP773tjgBiLWIXYumWCwEq3nLW+TUywEp8uEeag==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/typescript-estree@8.32.1':
+    resolution: {integrity: sha512-Y3AP9EIfYwBb4kWGb+simvPaqQoT5oJuzzj9m0i6FCY6SPvlomY2Ei4UEMm7+FXtlNJbor80ximyslzaQF6xhg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
@@ -694,6 +718,10 @@ packages:
 
   '@typescript-eslint/visitor-keys@8.31.1':
     resolution: {integrity: sha512-I+/rgqOVBn6f0o7NDTmAPWWC6NuqhV174lfYvAm9fUaWeiefLdux9/YI3/nLugEn9L8fcSi0XmpKi/r5u0nmpw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.32.1':
+    resolution: {integrity: sha512-ar0tjQfObzhSaW3C3QNmTc5ofj0hDoNQ5XWrCy6zDyabdr0TWhCkClp+rywGNj/odAFBVzzJrK4tEq5M4Hmu4w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitest/coverage-v8@3.1.2':
@@ -3483,17 +3511,50 @@ snapshots:
 
   '@types/resolve@1.20.2': {}
 
+  '@typescript-eslint/parser@8.32.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.32.1
+      '@typescript-eslint/types': 8.32.1
+      '@typescript-eslint/typescript-estree': 8.32.1(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.32.1
+      debug: 4.4.0
+      eslint: 9.26.0(jiti@2.4.2)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@8.31.1':
     dependencies:
       '@typescript-eslint/types': 8.31.1
       '@typescript-eslint/visitor-keys': 8.31.1
 
+  '@typescript-eslint/scope-manager@8.32.1':
+    dependencies:
+      '@typescript-eslint/types': 8.32.1
+      '@typescript-eslint/visitor-keys': 8.32.1
+
   '@typescript-eslint/types@8.31.1': {}
+
+  '@typescript-eslint/types@8.32.1': {}
 
   '@typescript-eslint/typescript-estree@8.31.1(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/types': 8.31.1
       '@typescript-eslint/visitor-keys': 8.31.1
+      debug: 4.4.0
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.1
+      ts-api-utils: 2.1.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.32.1(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.32.1
+      '@typescript-eslint/visitor-keys': 8.32.1
       debug: 4.4.0
       fast-glob: 3.3.3
       is-glob: 4.0.3
@@ -3518,6 +3579,11 @@ snapshots:
   '@typescript-eslint/visitor-keys@8.31.1':
     dependencies:
       '@typescript-eslint/types': 8.31.1
+      eslint-visitor-keys: 4.2.0
+
+  '@typescript-eslint/visitor-keys@8.32.1':
+    dependencies:
+      '@typescript-eslint/types': 8.32.1
       eslint-visitor-keys: 4.2.0
 
   '@vitest/coverage-v8@3.1.2(vitest@3.1.2)':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       vitest:
         specifier: 3.1.2
         version: 3.1.2(@types/node@22.15.3)(@vitest/ui@3.1.2)(jiti@2.4.2)(yaml@2.7.1)
+      vue-eslint-parser:
+        specifier: 10.1.3
+        version: 10.1.3(eslint@9.26.0(jiti@2.4.2))
 
 packages:
 
@@ -2899,6 +2902,12 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  vue-eslint-parser@10.1.3:
+    resolution: {integrity: sha512-dbCBnd2e02dYWsXoqX5yKUZlOt+ExIpq7hmHKPb5ZqKcjf++Eo0hMseFTZMLKThrUk61m+Uv6A2YSBve6ZvuDQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
@@ -5837,6 +5846,19 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vue-eslint-parser@10.1.3(eslint@9.26.0(jiti@2.4.2)):
+    dependencies:
+      debug: 4.4.0
+      eslint: 9.26.0(jiti@2.4.2)
+      eslint-scope: 8.3.0
+      eslint-visitor-keys: 4.2.0
+      espree: 10.3.0
+      esquery: 1.6.0
+      lodash: 4.17.21
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - supports-color
 
   wcwidth@1.0.1:
     dependencies:

--- a/src/constants/constant.ts
+++ b/src/constants/constant.ts
@@ -8,3 +8,4 @@ export const REACTIVE_FUNCTIONS = [
   'storeToRefs',
 ] as const;
 export const COMPOSABLES_FUNCTION_PATTERN: RegExp = /^use[A-Z]/;
+export const TEMPLATE_ONLY_DIRECTIVES = ['if', 'else', 'else-if', 'for'] as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import type { ESLint, Linter } from 'eslint';
 import { version } from '../package.json';
 import { requireReactiveValueSuffix } from './rules/require-reactive-value-suffix';
+import { restrictDirectiveToTemplate } from './rules/restrict-directive-to-template';
 import { storeStateSuffix } from './rules/store-state-suffix';
 
 type RuleDefinitions = (typeof plugin)['rules'];
@@ -18,6 +19,7 @@ const plugin = {
   rules: {
     'store-state-suffix': storeStateSuffix,
     'require-reactive-value-suffix': requireReactiveValueSuffix,
+    'restrict-directive-to-template': restrictDirectiveToTemplate,
   },
 } satisfies ESLint.Plugin;
 

--- a/src/rules/restrict-directive-to-template.ts
+++ b/src/rules/restrict-directive-to-template.ts
@@ -1,0 +1,75 @@
+import type { TSESLint } from '@typescript-eslint/utils';
+import type { AST as VAST } from 'vue-eslint-parser';
+import { TEMPLATE_ONLY_DIRECTIVES } from '../constants/constant';
+import { createVueElementReportData, getTypeCheckingServices } from '../helpers/types';
+import { createEslintRule } from '../utils';
+
+const MESSAGE_ID = 'restrict-directive-to-template' as const;
+
+type MessageId = typeof MESSAGE_ID;
+type RuleContext = Readonly<TSESLint.RuleContext<MessageId, unknown[]>>;
+
+/**
+ * 特定のディレクティブがtemplateタグで使用されていなかった場合にESLintの警告を出す処理
+ * @param element Vueのtemplate要素
+ * @param context ESLintルールのコンテキスト
+ * @returns templateタグ以外で特定のディレクティブが使用されていた場合はエラーを報告
+ */
+const processVElement = (element: VAST.VElement, context: RuleContext) => {
+  if (element.rawName === 'template') {
+    return;
+  }
+
+  for (const attribute of element.startTag.attributes) {
+    if (!attribute.directive) {
+      continue;
+    }
+
+    const directiveKey = attribute.key;
+    const directiveName = directiveKey.name.name;
+
+    if (!TEMPLATE_ONLY_DIRECTIVES.includes(directiveName as (typeof TEMPLATE_ONLY_DIRECTIVES)[number])) {
+      continue;
+    }
+
+    context.report(createVueElementReportData(attribute, MESSAGE_ID, directiveName));
+  }
+};
+
+/**
+ * 特定のディレクティブをtemplateタグでのみ使用することを強制するESLintルール
+ *
+ * @example
+ * // ルールの使用例
+ * <template>
+ *  <div v-if="condition">...</div> <!-- NG -->
+ * </template>
+ *
+ * <template>
+ *  <template v-if="condition"> <!-- OK -->
+ *    <div>...</div>
+ *  </template>
+ * </template>
+ */
+export const restrictDirectiveToTemplate = createEslintRule<[], MessageId>({
+  name: 'restrict-directive-to-template',
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Rule that enforces specific directives to be used only in template tags',
+    },
+    messages: {
+      [MESSAGE_ID]: 'v-{{name}} directive should only be used in template tags',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context: RuleContext) {
+    const { parserServices } = getTypeCheckingServices(context);
+    const { defineTemplateBodyVisitor } = parserServices;
+
+    return defineTemplateBodyVisitor({
+      VElement: (element) => processVElement(element, context),
+    });
+  },
+});

--- a/src/types/parser.d.ts
+++ b/src/types/parser.d.ts
@@ -1,0 +1,15 @@
+import type { ParserServicesWithTypeInformation } from '@typescript-eslint/utils';
+import type { AST as VAST } from 'vue-eslint-parser';
+
+export interface TemplateBodyVisitor {
+  VElement: (node: VAST.VElement) => void;
+}
+
+export interface VueParserServices {
+  defineTemplateBodyVisitor: (
+    templateBodyVisitor: TemplateBodyVisitor,
+    scriptVisitor?: Record<string, (node: unknown) => void>,
+  ) => Record<string, (node: VAST.VNode) => void>;
+}
+
+export type ExtendedParserServices = ParserServicesWithTypeInformation & VueParserServices;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ import type { RuleContext, RuleMetaData } from '@typescript-eslint/utils/ts-esli
 import type { Rule } from 'eslint';
 
 /** ドキュメントが存在するルール名のリスト */
-const hasDocumentList = ['store-state-suffix'];
+const hasDocumentList = ['store-state-suffix', 'require-reactive-value-suffix', 'restrict-directive-to-template'];
 /** ドキュメントの GitHub URL */
 const blobDocsUrl = 'https://github.com/XeicuLy/eslint-plugin-xeiculy/blob/main/src/docs/';
 /** テストファイルの GitHub URL */


### PR DESCRIPTION
## 📝 プルリクエストの種類 / Pull Request Type

- [x] 機能追加 / Feature
- [ ] バグ修正 / Bug Fix
- [ ] パフォーマンス改善 / Performance Improvement
- [ ] リファクタリング / Refactoring
- [ ] ドキュメント / Documentation
- [ ] テスト / Test
- [ ] CI / CD
- [ ] その他 / Other

## 🔍 変更内容 / Changes Made

### 📋 概要 / Summary

Vue・Nuxtにおいて特定のディレクティブをtemplateタグでのみ使用することを強制するルールの追加

### ✅ 実施した変更 / Changes Implemented

- 1fd334b32aeb000b029bf95825ad86f5f80296f9

### ❌ 対象外の変更 / Out of Scope

- テストの追加


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - Vueディレクティブ（v-if, v-else, v-else-if, v-for）の使用を<template>タグ内のみに制限する新しいESLintルールを追加しました。
- **改善**
  - ESLintプラグインに新しいルール「restrict-directive-to-template」を追加しました。
  - TypeScript型定義にVueテンプレートパーサーサービスの型を追加しました。
- **開発環境**
  - 開発用依存関係に「@typescript-eslint/parser」と「vue-eslint-parser」を追加しました。
- **その他**
  - コードのフォーマットや配列表記の統一を行いました。
  - Prettierの対象外ファイルにCHANGELOG.mdを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->