### PR TITLE
refactor type Adjust JSON/JSONC formatting and linting settings with Prettier and Biome

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -34,5 +34,3 @@ logs
 **/*.mts
 **/*.jsx
 **/*.tsx
-**/*.json
-**/*.jsonc

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
     "source.organizeImports.biome": "explicit",
     "quickfix.biome": "explicit"
   },
-  "[javascript][javascriptreact][typescript][typescriptreact][json][jsonc][css]": {
+  "[css][javascript][javascriptreact][typescript][typescriptreact]": {
     "editor.defaultFormatter": "biomejs.biome"
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![npm version][npm-version-src]][npm-version-href]
 
-![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/XeicuLy/eslint-plugin-xeiculy?utm_source=oss&utm_medium=github&utm_campaign=XeicuLy%2Feslint-plugin-xeiculy&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
-
 ## License
 
 [MIT](./LICENSE) License © 2025–Present [XeicuLy](https://github.com/XeicuLy)

--- a/biome.json
+++ b/biome.json
@@ -51,9 +51,7 @@
   },
   "json": {
     "formatter": {
-      "enabled": true,
-      "lineWidth": 120,
-      "indentStyle": "space"
+      "enabled": false
     },
     "linter": {
       "enabled": true

--- a/package.json
+++ b/package.json
@@ -83,10 +83,10 @@
     }
   },
   "lint-staged": {
-    "**/*.{css,js,ts,cjs,mjs,cts,mts,jsx,tsx,json,jsonc}": [
+    "**/*.{css,js,ts,cjs,mjs,cts,mts,jsx,tsx}": [
       "biome check --write --no-errors-on-unmatched"
     ],
-    "**/*.{md,html,yaml,yml}": [
+    "**/*.{json,jsonc,md,html,yaml,yml}": [
       "prettier --write"
     ]
   },

--- a/src/types/parser.d.ts
+++ b/src/types/parser.d.ts
@@ -10,8 +10,6 @@ export interface ScriptVisitor {
   [key: string]: (node: TSESTree.Node) => void;
 }
 
-export type TemplateBodyVisitorKeys = keyof TemplateBodyVisitor;
-
 export interface VueParserServices {
   defineTemplateBodyVisitor: (templateBodyVisitor: TemplateBodyVisitor, scriptVisitor?: ScriptVisitor) => RuleListener;
 }

--- a/src/types/parser.d.ts
+++ b/src/types/parser.d.ts
@@ -1,15 +1,19 @@
-import type { ParserServicesWithTypeInformation } from '@typescript-eslint/utils';
+import type { ParserServicesWithTypeInformation, TSESTree } from '@typescript-eslint/utils';
+import type { RuleListener } from '@typescript-eslint/utils/ts-eslint';
 import type { AST as VAST } from 'vue-eslint-parser';
 
 export interface TemplateBodyVisitor {
-  VElement: (node: VAST.VElement) => void;
+  VElement?: (node: VAST.VElement) => void;
 }
 
+export interface ScriptVisitor {
+  [key: string]: (node: TSESTree.Node) => void;
+}
+
+export type TemplateBodyVisitorKeys = keyof TemplateBodyVisitor;
+
 export interface VueParserServices {
-  defineTemplateBodyVisitor: (
-    templateBodyVisitor: TemplateBodyVisitor,
-    scriptVisitor?: Record<string, (node: unknown) => void>,
-  ) => Record<string, (node: VAST.VNode) => void>;
+  defineTemplateBodyVisitor: (templateBodyVisitor: TemplateBodyVisitor, scriptVisitor?: ScriptVisitor) => RuleListener;
 }
 
 export type ExtendedParserServices = ParserServicesWithTypeInformation & VueParserServices;

--- a/src/types/parser.d.ts
+++ b/src/types/parser.d.ts
@@ -6,9 +6,9 @@ export interface TemplateBodyVisitor {
   VElement?: (node: VAST.VElement) => void;
 }
 
-export interface ScriptVisitor {
-  [key: string]: (node: TSESTree.Node) => void;
-}
+export type ScriptVisitor = {
+  [K in keyof RuleListener]?: (node: Extract<Parameters<RuleListener[K]>[0], TSESTree.Node>) => void;
+};
 
 export interface VueParserServices {
   defineTemplateBodyVisitor: (templateBodyVisitor: TemplateBodyVisitor, scriptVisitor?: ScriptVisitor) => RuleListener;


### PR DESCRIPTION
## 📝 プルリクエストの種類 / Pull Request Type

- [ ] 機能追加 / Feature
- [ ] バグ修正 / Bug Fix
- [x] パフォーマンス改善 / Performance Improvement
- [ ] リファクタリング / Refactoring
- [x] ドキュメント / Documentation
- [ ] テスト / Test
- [ ] CI / CD
- [ ] その他 / Other

## 🔍 変更内容 / Changes Made

### 📋 概要 / Summary

型定義修正とREADMEの修正、そして、フォーマッターの変更

### ✅ 実施した変更 / Changes Implemented

- a0f289725f3c54b393869c7b284e69ca31cc33e0
- 0d5c00156dff917c06fbc5df7327e093ed150e40
- 89b3b67454af227cecff2f2a06f1491f2452ddff

### ❌ 対象外の変更 / Out of Scope

n/a

## 🔗 関連Issue / Related Issues

close #43 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **ドキュメント**
  - READMEから「CodeRabbit Pull Request Reviews」バッジを削除しました。

- **スタイル**
  - `.prettierignore`の設定を変更し、JSONおよびJSONCファイルもPrettierのフォーマット対象としました。

- **チョア**
  - VSCode設定でJSON/JSONCファイルに対するデフォルトフォーマッター指定を削除しました。
  - `biome.json`でJSONファイルのフォーマット機能を無効化しました。
  - `lint-staged`の設定を調整し、JSON/JSONCファイルはPrettierでフォーマットされるようになりました。

- **新機能**
  - 型定義に`ScriptVisitor`型エイリアスを追加しました。
  - `TemplateBodyVisitor`インターフェースの`VElement`プロパティをオプショナルに変更しました。
  - `VueParserServices`のメソッドシグネチャを更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->